### PR TITLE
make purescript-quickcheck a real dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,12 +18,12 @@
     "purescript-arrays": "^0.4.4",
     "purescript-strings": "^0.7.1",
     "purescript-globals": "^0.2.2",
-    "purescript-integers": "^0.2.1"
+    "purescript-integers": "^0.2.1",
+    "purescript-quickcheck": "~0.12.2"
   },
   "devDependencies": {
     "purescript-debugger": "~0.1.1",
     "purescript-test-unit": "~4.1.0",
-    "purescript-quickcheck": "~0.12.2",
     "purescript-quickcheck-laws": "~0.1.0",
     "purescript-benchotron": "~3.0.4"
   }


### PR DESCRIPTION
This causes builds of packages that depend on `purescript-hugenums` to fail, in case they do not also depend on `purescript-quickcheck`. The reason is that QuickCheck is imported from inside this library (not just its tests).
